### PR TITLE
4.0.0-rc.18

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -10,11 +10,16 @@ module.exports = class extends Generator {
 	constructor(args, opts) {
 		// Calling the super constructor is important so our generator is correctly set up
 		super(args, opts);
+
+		this.argument('name', {type: String, required: false});
+		this.argument('deployDir', {type: String, default: '../../web'});
 	}
 
 	initializing() {
 		this.pkg = require('../../package.json');
 		this.answer = 'new';
+
+		this.selfName = this.pkg['name'];
 
 		let notifier = updateNotifier({
 			pkg,
@@ -22,7 +27,6 @@ module.exports = class extends Generator {
 		});
 
 		if (notifier.update) {
-
 			this.log(yosay(
 				'I say, there seems to be an update to the generator! Go and fetch it!'
 			));
@@ -32,75 +36,85 @@ module.exports = class extends Generator {
 			notifier = null;
 
 			return true;
-
 		}
 	}
 
 	async prompting() {
 
-		this.log(yosay(
-			'Welcome to the BarkleyREI project generator!\nv' + this.pkg.version
-		));
+		this.composeOptions = {};
 
-		this.answers = await this.prompt({
-			type: 'list',
-			name: 'command',
-			message: 'What would you like to do?',
-			default: 'Create a New Project',
-			choices: [
-				'Create a New Project',
-				'Create a Template',
-				'Create an Organism',
-				'Create a Molecule',
-				'Create an Atom',
-				'Create a Partial (LEGACY)',
-				'Create a Module (LEGACY)'
-				// 'Import a Pattern',
-				// 'Update Your Project'
-			]
-		});
+		if (typeof this.options.name === 'undefined' || this.options.name === '') {
 
-		switch (this.answers.command) {
-			case 'Create a Partial (LEGACY)':
-				this.answer = 'partial';
-				// this.composeWith('brei-next:partial', {});
-				break;
-			case 'Create a Module (LEGACY)':
-				this.answer = 'module';
-				// this.composeWith('brei-next:module', {});
-				break;
-			case 'Create a Template':
-				this.answer = 'template';
-				// this.composeWith('brei-next:template', {});
-				break;
-			case 'Create an Organism':
-				this.answer = 'organism';
-				// this.composeWith('brei-next:template', {});
-				break;
-			case 'Create a Molecule':
-				this.answer = 'molecule';
-				// this.composeWith('brei-next:template', {});
-				break;
-			case 'Create an Atom':
-				this.answer = 'atom';
-				// this.composeWith('brei-next:template', {});
-				break;
-			// case 'Import a Pattern':
-			// this.answer = 'pattern';
-			// this.composeWith('brei-next:pattern', {});
-			// break;
-			// case 'Update Your Project':
-			// this.answer = 'update';
-			// this.composeWith('brei-next:update', {});
-			// break;
-			default: //'Create a New Project'
-				// this.composeWith('brei-next:new');
-				break;
+			this.log(yosay(
+				'Welcome to the BarkleyREI project generator!\nv' + this.pkg.version
+			));
+
+			this.answers = await this.prompt({
+				type: 'list',
+				name: 'command',
+				message: 'What would you like to do?',
+				default: 'Create a New Project',
+				choices: [
+					'Create a New Project',
+					'Create a Template',
+					'Create an Organism',
+					'Create a Molecule',
+					'Create an Atom',
+					'Create a Partial (LEGACY)',
+					'Create a Module (LEGACY)'
+					// 'Import a Pattern',
+					// 'Update Your Project'
+				]
+			});
+
+			switch (this.answers.command) {
+				case 'Create a Partial (LEGACY)':
+					this.answer = 'partial';
+					// this.composeWith('brei-next:partial', {});
+					break;
+				case 'Create a Module (LEGACY)':
+					this.answer = 'module';
+					// this.composeWith('brei-next:module', {});
+					break;
+				case 'Create a Template':
+					this.answer = 'template';
+					// this.composeWith('brei-next:template', {});
+					break;
+				case 'Create an Organism':
+					this.answer = 'organism';
+					// this.composeWith('brei-next:template', {});
+					break;
+				case 'Create a Molecule':
+					this.answer = 'molecule';
+					// this.composeWith('brei-next:template', {});
+					break;
+				case 'Create an Atom':
+					this.answer = 'atom';
+					// this.composeWith('brei-next:template', {});
+					break;
+				// case 'Import a Pattern':
+				// this.answer = 'pattern';
+				// this.composeWith('brei-next:pattern', {});
+				// break;
+				// case 'Update Your Project':
+				// this.answer = 'update';
+				// this.composeWith('brei-next:update', {});
+				// break;
+				default: //'Create a New Project'
+					// this.composeWith('brei-next:new');
+					break;
+			}
+
+		} else {
+			this.answer = 'new';
+			this.composeOptions = {
+				name: this.options.name,
+				deployDir: this.options.deployDir
+			};
 		}
-
 	}
 
 	install() {
-		this.composeWith('brei-next:' + this.answer);
+		this.composeWith(require.resolve(this.selfName + '/generators/' + this.answer), this.composeOptions);
 	}
 };

--- a/generators/new/index.js
+++ b/generators/new/index.js
@@ -8,15 +8,15 @@ const editjson = require('edit-json-file');
 module.exports = class extends Generator {
 
 	constructor(args, opts) {
-
 		// Calling the super constructor is important so our generator is correctly set up
 		super(args, opts);
 
 		this.pkg = require('../../package.json');
 
 		this.genver = this.pkg['version'];
-		// this.debug = 'false';
 
+		this.argument('name', {type: String, required: false});
+		this.argument('deployDir', {type: String, default: '../../web'});
 	}
 
 	initializing() {
@@ -28,30 +28,41 @@ module.exports = class extends Generator {
 
 	async prompting() {
 
-		// Ask the people what they want.
-		this.answers = await this.prompt([
-			{
-				type: 'input',
-				name: 'appname',
-				message: 'Name of Client (e.g. NOVA, Corpus, Times Square NYC)',
-				default: 'static'
-			}, {
-				type: 'input',
-				name: 'stash',
-				message: 'Stash Repository Clone URL (ssh:// .git) (Optional)',
-				default: ''
-			}, {
-				type: 'input',
-				name: 'deployDirectory',
-				message: 'Deploy directory (relative to current path)',
-				default: '../../web'
-			}
-		]);
+		if (typeof this.options.name === 'undefined' || this.options.name === '') {
 
-		this.appname = this.answers.appname;
-		this.appslug = _s.slugify(this.answers.appname);
-		this.stash = this.answers.stash;
-		this.deployDirectory = this.answers.deployDirectory;
+			// Ask the people what they want.
+			this.answers = await this.prompt([
+				{
+					type: 'input',
+					name: 'appname',
+					message: 'Name of Client (e.g. NOVA, Corpus, Times Square NYC)',
+					default: 'static'
+				}, {
+					type: 'input',
+					name: 'stash',
+					message: 'Stash Repository Clone URL (ssh:// .git) (Optional)',
+					default: ''
+				}, {
+					type: 'input',
+					name: 'deployDirectory',
+					message: 'Deploy directory (relative to current path)',
+					default: '../../web'
+				}
+			]);
+
+			this.appname = this.answers.appname;
+			this.appslug = _s.slugify(this.answers.appname);
+			this.stash = this.answers.stash;
+			this.deployDirectory = this.answers.deployDirectory;
+
+		} else {
+
+			this.appname = this.options.name;
+			this.appslug = _s.slugify(this.options.name);
+			this.stash = '';
+			this.deployDirectory = this.options.deployDir;
+
+		}
 
 	}
 
@@ -71,6 +82,7 @@ module.exports = class extends Generator {
 		this.newPJ.set('description', this.scaffoldPJ.get('description'));
 		this.newPJ.set('author', this.scaffoldPJ.get('author'));
 		this.newPJ.set('license', this.scaffoldPJ.get('license'));
+		this.newPJ.set('browserslist', this.scaffoldPJ.get('browserslist'));
 		this.newPJ.set('dependencies', this.scaffoldPJ.get('dependencies'));
 		this.newPJ.set('devDependencies', this.scaffoldPJ.get('devDependencies'));
 		this.newPJ.set('scripts', this.scaffoldPJ.get('scripts'));
@@ -231,6 +243,7 @@ module.exports = class extends Generator {
 
 		// Delete crap we don't need
 		this.fs.delete(this.destinationPath('.github/'));
+		this.fs.delete(this.destinationPath('.travis.yml'));
 		this.fs.delete(this.destinationPath('app/scss/README.md'));
 		this.fs.delete(this.destinationPath('app/scss/package.json'));
 		this.fs.delete(this.destinationPath('app/scss/.travis.yml'));

--- a/generators/new/index.js
+++ b/generators/new/index.js
@@ -114,7 +114,7 @@ module.exports = class extends Generator {
 		);
 
 		// brei-project-scaffold
-		var scaffoldJson = this.fs.readJSON(
+		let scaffoldJson = this.fs.readJSON(
 			this.templatePath('../../../node_modules/brei-project-scaffold/package.json')
 		);
 		this.breiJ.set('brei-project-scaffold', scaffoldJson.version);
@@ -132,7 +132,7 @@ module.exports = class extends Generator {
 		this.fs.delete(this.destinationPath('package.json'));
 
 		// brei-sass-boilerplate
-		var sassJson = this.fs.readJSON(
+		let sassJson = this.fs.readJSON(
 			this.templatePath('../../../node_modules/brei-sass-boilerplate/package.json')
 		);
 		this.breiJ.set('brei-sass-boilerplate', sassJson.version);
@@ -165,7 +165,7 @@ module.exports = class extends Generator {
 		);
 
 		// brei-sass-mixins
-		var mixinJson = this.fs.readJSON(
+		let mixinJson = this.fs.readJSON(
 			this.templatePath('../../../node_modules/brei-sass-mixins/package.json')
 		);
 		this.breiJ.set('brei-sass-mixins', mixinJson.version);
@@ -180,7 +180,10 @@ module.exports = class extends Generator {
 		);
 
 		// brei-assemble-structure
-		var assembleJson = this.fs.readJSON(
+		let jQueryJson = this.fs.readJSON(
+			this.templatePath('../../../node_modules/jquery/package.json')
+		);
+		let assembleJson = this.fs.readJSON(
 			this.templatePath('../../../node_modules/brei-assemble-structure/package.json')
 		);
 		this.breiJ.set('brei-assemble-structure', assembleJson.version);
@@ -194,6 +197,13 @@ module.exports = class extends Generator {
 			}
 		);
 		this.fs.copyTpl(
+			this.templatePath('../../../node_modules/brei-assemble-structure/includes/_js-vendor.hbs'),
+			this.destinationPath('app/assemble/includes/_js-vendor.hbs'),
+			{
+				'jqueryversion': jQueryJson.version
+			}
+		);
+		this.fs.copyTpl(
 			this.templatePath('../../../node_modules/brei-assemble-structure/index.hbs'),
 			this.destinationPath('app/assemble/index.hbs'),
 			{
@@ -202,7 +212,7 @@ module.exports = class extends Generator {
 		);
 
 		// brei-assemble-helpers
-		var helpersJson = this.fs.readJSON(
+		let helpersJson = this.fs.readJSON(
 			this.templatePath('../../../node_modules/brei-assemble-helpers/package.json')
 		);
 		this.breiJ.set('brei-assemble-helpers', helpersJson.version);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-brei-next",
-	"version": "4.0.0-rc.19",
+	"version": "4.0.0-rc.18",
 	"description": "Bootstrap client projects at BarkleyREI",
 	"license": "MIT",
 	"main": "generators/app/index.js",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"update-notifier": "~4.1.0",
 		"yeoman-assert": "~3.1.1",
 		"yeoman-generator": "~4.9.0",
-		"yeoman-test": "~2.4.1",
+		"yeoman-test": "~2.5.0",
 		"yosay": "~2.0.2"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-brei-next",
-	"version": "4.0.0-rc.18",
+	"version": "4.0.0-rc.19",
 	"description": "Bootstrap client projects at BarkleyREI",
 	"license": "MIT",
 	"main": "generators/app/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-brei-next",
-	"version": "4.0.0-rc.17",
+	"version": "4.0.0-rc.18",
 	"description": "Bootstrap client projects at BarkleyREI",
 	"license": "MIT",
 	"main": "generators/app/index.js",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"underscore.string": "~3.3.5",
 		"update-notifier": "~4.1.0",
 		"yeoman-assert": "~3.1.1",
-		"yeoman-generator": "~4.9.0",
+		"yeoman-generator": "~4.10.0",
 		"yeoman-test": "~2.4.1",
 		"yosay": "~2.0.2"
 	},


### PR DESCRIPTION
# Version 4.0.0-rc.18

Rewrite generator init using updated yeoman syntax. Generator can also now be generated via a one-liner, for use in scripting and tests. Also dynamically injects a jQuery CDN on project init.

## Changes

fix: upgrade yeoman-generator from 4.9.0 to 4.10.0
- Necessitated a rewrite of the init script

fix: upgrade yeoman-test from 2.4.1 to 2.5.0
feat: New generator can be triggered with one-liner using arguments.
feat: Dynamically inject jQuery CDN on project init.